### PR TITLE
feat: add commit path to scope changelogs to single directories

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,8 +1,6 @@
 name: 'Test the action'
 on:
   pull_request:
-    branches:
-      - master
 
 jobs:
   test-json:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -631,3 +631,43 @@ jobs:
           else
             echo "Changelog config not applied" && exit 1
           fi
+
+  test-commit-path:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          path: "./"
+
+      - run: npm ci --prod
+
+      - run: touch ./fake-file.log
+      - run: "git config --global user.email 'changelog@github.com'"
+      - run: "git config --global user.name 'Awesome Github action'"
+      - run: "git add . && git commit -m 'feat: Added fake file so MINOR version will be bumped'"
+      - run: mkdir ./another-path
+      - run: cp ./test-file.json ./another-path/test-file.json
+      - run: touch ./another-path/another-fake-file.log
+      - run: "git add . && git commit -m 'fix: Added another fake file so PATCH version will be bumped'"
+
+      - name: Generate changelog
+        id: changelog
+        uses: ./
+        env:
+          ENV: 'dont-use-git'
+          EXPECTED_TAG: 'v1.4.6'
+        with:
+          github-token: ${{ secrets.github_token }}
+          version-file: './another-path/test-file.json'
+          commit-path: 'another-path'
+
+      - name: Show file
+        run: |
+          echo "$(<./another-path/test-file.json)"
+
+      - name: Test output
+        run: node ./test-output.js
+        env:
+          FILES: './another-path/test-file.json'
+          EXPECTED_VERSION: '1.4.6'

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ This action will bump version, tag commit and generate a changelog with conventi
 - **Optional** `fallback-version`: The fallback version, if no older one can be detected, or if it is the first one. Default `'0.1.0'`
 - **Optional** `config-file-path`: Path to the conventional changelog config file. If set, the preset setting will be ignored
 - **Optional** `pre-changelog-generation`: Path to the pre-changelog-generation script file. No hook by default.
+- **Optional** `commit-path`: Generate a changelog scoped to a specific directory.
 
 ### Pre-Commit hook
 

--- a/action.yml
+++ b/action.yml
@@ -107,6 +107,9 @@ inputs:
     description: 'Path to the pre-changelog-generation script file'
     required: false
 
+  commit-path:
+    description: 'Generate a changelog scoped to a specific directory'
+    required: false
 
 outputs:
   changelog:

--- a/src/helpers/generateChangelog.js
+++ b/src/helpers/generateChangelog.js
@@ -10,7 +10,7 @@ const conventionalChangelog = require('conventional-changelog')
  * @param releaseCount
  * @returns {*}
  */
-const getChangelogStream = (tagPrefix, preset, version, releaseCount, config) => conventionalChangelog({
+const getChangelogStream = (tagPrefix, preset, version, releaseCount, path, config) => conventionalChangelog({
     preset,
     releaseCount: parseInt(releaseCount, 10),
     tagPrefix,
@@ -20,7 +20,9 @@ const getChangelogStream = (tagPrefix, preset, version, releaseCount, config) =>
     version,
     currentTag: `${tagPrefix}${version}`,
   },
-  {},
+  {
+    path
+  },
   config && config.parserOpts,
   config && config.writerOpts
 )
@@ -36,8 +38,8 @@ module.exports = getChangelogStream
  * @param releaseCount
  * @returns {Promise<string>}
  */
-module.exports.generateStringChangelog = (tagPrefix, preset, version, releaseCount, config) => new Promise((resolve, reject) => {
-  const changelogStream = getChangelogStream(tagPrefix, preset, version, releaseCount, config)
+module.exports.generateStringChangelog = (tagPrefix, preset, version, releaseCount, path, config) => new Promise((resolve, reject) => {
+  const changelogStream = getChangelogStream(tagPrefix, preset, version, releaseCount, path, config)
 
   let changelog = ''
 
@@ -58,8 +60,8 @@ module.exports.generateStringChangelog = (tagPrefix, preset, version, releaseCou
  * @param releaseCount
  * @returns {Promise<>}
  */
-module.exports.generateFileChangelog = (tagPrefix, preset, version, fileName, releaseCount, config) => new Promise((resolve) => {
-  const changelogStream = getChangelogStream(tagPrefix, preset, version, releaseCount, config)
+module.exports.generateFileChangelog = (tagPrefix, preset, version, fileName, releaseCount, path, config) => new Promise((resolve) => {
+  const changelogStream = getChangelogStream(tagPrefix, preset, version, releaseCount, path, config)
 
   changelogStream
     .pipe(fs.createWriteStream(fileName))

--- a/src/index.js
+++ b/src/index.js
@@ -42,6 +42,7 @@ async function run() {
     const skipEmptyRelease = core.getInput('skip-on-empty').toLowerCase() === 'true'
     const conventionalConfigFile = core.getInput('config-file-path')
     const preChangelogGenerationFile = core.getInput('pre-changelog-generation')
+    const path = core.getInput('commit-path')
 
     core.info(`Using "${preset}" preset`)
     core.info(`Using "${gitCommitMessage}" as commit message`)
@@ -53,6 +54,7 @@ async function run() {
     core.info(`Using "${tagPrefix}" as tag prefix`)
     core.info(`Using "${outputFile}" as output file`)
     core.info(`Using "${conventionalConfigFile}" as config file`)
+    core.info(`Using "${path}" as commit path`)
 
     if (preCommitFile) {
       core.info(`Using "${preCommitFile}" as pre-commit script`)
@@ -72,7 +74,7 @@ async function run() {
 
     const config = conventionalConfigFile && requireScript(conventionalConfigFile)
 
-    conventionalRecommendedBump({ preset, tagPrefix, config }, async (error, recommendation) => {
+    conventionalRecommendedBump({ preset, tagPrefix, config, path }, async (error, recommendation) => {
       if (error) {
         core.setFailed(error.message)
         return
@@ -134,7 +136,7 @@ async function run() {
       }
 
       // Generate the string changelog
-      const stringChangelog = await changelog.generateStringChangelog(tagPrefix, preset, newVersion, 1, config)
+      const stringChangelog = await changelog.generateStringChangelog(tagPrefix, preset, newVersion, 1, path, config)
       core.info('Changelog generated')
       core.info(stringChangelog)
 
@@ -152,7 +154,7 @@ async function run() {
       // If output file === 'false' we don't write it to file
       if (outputFile !== 'false') {
         // Generate the changelog
-        await changelog.generateFileChangelog(tagPrefix, preset, newVersion, outputFile, releaseCount, config)
+        await changelog.generateFileChangelog(tagPrefix, preset, newVersion, outputFile, releaseCount, path, config)
       }
 
       if (!skipCommit) {


### PR DESCRIPTION
Add the `commit-path` argument so generated changelogs can be scoped to a path in the repository.