### PR TITLE
feat: add skip-tag option

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -709,46 +709,46 @@ jobs:
           EXPECTED_VERSION: '1.1.0'
           EXPECTED_VERSION_PATH: 'project.properties.revision'
 
-  test-skip-tag:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v2
-        with:
-          path: "./"
+  # test-skip-tag:
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - name: Checkout code
+  #       uses: actions/checkout@v2
+  #       with:
+  #         path: "./"
 
-      - run: npm ci --prod
+  #     - run: npm ci --prod
 
-      - run: "git config --global user.email 'changelog@github.com'"
-      - run: "git config --global user.name 'Awesome Github action'"
+  #     - run: "git config --global user.email 'changelog@github.com'"
+  #     - run: "git config --global user.name 'Awesome Github action'"
 
-      - run: git tag | xargs git tag -d
-      - name: Create fake tag
-        run: "git tag -a 'v0.55.8' -m 'v0.55.8'"
-      - run: touch ./fake-file.log
-      - run: "git add . && git commit -m 'fix: Added fake file so version will be bumped'"
+  #     - run: git tag | xargs git tag -d
+  #     - name: Create fake tag
+  #       run: "git tag -a 'v0.55.8' -m 'v0.55.8'"
+  #     - run: touch ./fake-file.log
+  #     - run: "git add . && git commit -m 'fix: Added fake file so version will be bumped'"
 
-      - name: Generate changelog
-        id: changelog
-        uses: ./
-        env:
-          ENV: 'dont-use-git'
-          EXPECTED_TAG: 'v0.55.8'
-          SKIPPED_COMMIT: true
-          SKIPPED_TAG: true
-          EXPECTED_NO_PUSH: true
-        with:
-          github-token: ${{ secrets.github_token }}
-          skip-commit: 'true'
-          skip-tag: 'true'
-          git-push: 'false'
+  #     - name: Generate changelog
+  #       id: changelog
+  #       uses: ./
+  #       env:
+  #         ENV: 'dont-use-git'
+  #         EXPECTED_TAG: 'v0.55.8'
+  #         SKIPPED_COMMIT: true
+  #         SKIPPED_TAG: true
+  #         EXPECTED_NO_PUSH: true
+  #       with:
+  #         github-token: ${{ secrets.github_token }}
+  #         skip-commit: 'true'
+  #         skip-tag: 'true'
+  #         git-push: 'false'
 
-      - name: Show file
-        run: |
-          echo "$(<test-file.json)"
+  #     - name: Show file
+  #       run: |
+  #         echo "$(<test-file.json)"
 
-      - name: Test output
-        run: node ./test-output.js
-        env:
-          FILES: 'test-file.json'
-          EXPECTED_VERSION: '1.5.0'
+  #     - name: Test output
+  #       run: node ./test-output.js
+  #       env:
+  #         FILES: 'test-file.json'
+  #         EXPECTED_VERSION: '1.5.0'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -708,3 +708,47 @@ jobs:
           FILES: 'test-file.xml'
           EXPECTED_VERSION: '1.1.0'
           EXPECTED_VERSION_PATH: 'project.properties.revision'
+
+  test-skip-tag:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          path: "./"
+
+      - run: npm ci --prod
+
+      - run: "git config --global user.email 'changelog@github.com'"
+      - run: "git config --global user.name 'Awesome Github action'"
+
+      - run: git tag | xargs git tag -d
+      - name: Create fake tag
+        run: "git tag -a 'v0.55.8' -m 'v0.55.8'"
+      - run: touch ./fake-file.log
+      - run: "git add . && git commit -m 'fix: Added fake file so version will be bumped'"
+
+      - name: Generate changelog
+        id: changelog
+        uses: ./
+        env:
+          ENV: 'dont-use-git'
+          EXPECTED_TAG: 'v0.55.8'
+          SKIPPED_COMMIT: true
+          SKIPPED_TAG: true
+          EXPECTED_NO_PUSH: true
+        with:
+          github-token: ${{ secrets.github_token }}
+          skip-commit: 'true'
+          skip-tag: 'true'
+          git-push: 'false'
+
+      - name: Show file
+        run: |
+          echo "$(<test-file.json)"
+
+      - name: Test output
+        run: node ./test-output.js
+        env:
+          FILES: 'test-file.json'
+          EXPECTED_VERSION: '1.5.0'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -124,6 +124,7 @@ jobs:
       - run: git tag | xargs git tag -d
       - name: Create fake tag
         run: "git tag -a 'v0.55.8' -m 'v0.55.8'"
+      - run: touch ./fake-file.log
       - run: "git add . && git commit -m 'fix: Added fake file so version will be bumped'"
 
       - name: Generate changelog
@@ -136,6 +137,7 @@ jobs:
         with:
           github-token: ${{ secrets.github_token }}
           skip-commit: 'true'
+          skip-version-file: 'true'
           
   test-git-no-pull:
     runs-on: ubuntu-latest
@@ -153,6 +155,7 @@ jobs:
       - run: git tag | xargs git tag -d
       - name: Create fake tag
         run: "git tag -a 'v0.55.8' -m 'v0.55.8'"
+      - run: touch ./fake-file.log
       - run: "git add . && git commit -m 'fix: Added fake file so version will be bumped'"
 
       - name: Generate changelog
@@ -167,6 +170,7 @@ jobs:
           github-token: ${{ secrets.github_token }}
           skip-commit: 'true'
           skip-git-pull: 'true'
+          skip-version-file: 'true'
 
   test-git-fallback:
     runs-on: ubuntu-latest
@@ -181,6 +185,7 @@ jobs:
       - run: touch ./fake-file.log
       - run: "git config --global user.email 'changelog@github.com'"
       - run: "git config --global user.name 'Awesome Github action'"
+      - run: touch ./fake-file.log
       - run: "git add . && git commit -m 'feat: Added fake file so version will be bumped'"
 
       - run: git tag | xargs git tag -d
@@ -195,6 +200,7 @@ jobs:
         with:
           github-token: ${{ secrets.github_token }}
           skip-commit: 'true'
+          skip-version-file: 'true'
 
   test-git-no-push:
     runs-on: ubuntu-latest
@@ -212,6 +218,7 @@ jobs:
       - run: git tag | xargs git tag -d
       - name: Create fake tag
         run: "git tag -a 'v0.55.8' -m 'v0.55.8'"
+      - run: touch ./fake-file.log
       - run: "git add . && git commit -m 'fix: Added fake file so version will be bumped'"
 
       - name: Generate changelog
@@ -226,6 +233,7 @@ jobs:
           github-token: ${{ secrets.github_token }}
           skip-commit: 'true'
           git-push: 'false'
+          skip-version-file: 'true'
 
   test-yaml:
     runs-on: ubuntu-latest
@@ -709,46 +717,47 @@ jobs:
           EXPECTED_VERSION: '1.1.0'
           EXPECTED_VERSION_PATH: 'project.properties.revision'
 
-  # test-skip-tag:
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - name: Checkout code
-  #       uses: actions/checkout@v2
-  #       with:
-  #         path: "./"
+  test-skip-tag:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          path: "./"
 
-  #     - run: npm ci --prod
+      - run: npm ci --prod
 
-  #     - run: "git config --global user.email 'changelog@github.com'"
-  #     - run: "git config --global user.name 'Awesome Github action'"
+      - run: "git config --global user.email 'changelog@github.com'"
+      - run: "git config --global user.name 'Awesome Github action'"
 
-  #     - run: git tag | xargs git tag -d
-  #     - name: Create fake tag
-  #       run: "git tag -a 'v0.55.8' -m 'v0.55.8'"
-  #     - run: touch ./fake-file.log
-  #     - run: "git add . && git commit -m 'fix: Added fake file so version will be bumped'"
+      - run: git tag | xargs git tag -d
+      - name: Create fake tag
+        run: "git tag -a 'v0.55.8' -m 'v0.55.8'"
+      - run: touch ./fake-file.log
+      - run: "git add . && git commit -m 'feat: Added fake file so version will be bumped'"
 
-  #     - name: Generate changelog
-  #       id: changelog
-  #       uses: ./
-  #       env:
-  #         ENV: 'dont-use-git'
-  #         EXPECTED_TAG: 'v0.55.8'
-  #         SKIPPED_COMMIT: true
-  #         SKIPPED_TAG: true
-  #         EXPECTED_NO_PUSH: true
-  #       with:
-  #         github-token: ${{ secrets.github_token }}
-  #         skip-commit: 'true'
-  #         skip-tag: 'true'
-  #         git-push: 'false'
+      - name: Generate changelog
+        id: changelog
+        uses: ./
+        env:
+          ENV: 'dont-use-git'
+          EXPECTED_TAG: 'v0.55.8'
+          SKIPPED_COMMIT: true
+          SKIPPED_TAG: true
+          EXPECTED_NO_PUSH: true
+        with:
+          github-token: ${{ secrets.github_token }}
+          version-file: 'test-file.json'
+          skip-commit: 'true'
+          skip-tag: 'true'
+          git-push: 'false'
 
-  #     - name: Show file
-  #       run: |
-  #         echo "$(<test-file.json)"
+      - name: Show file
+        run: |
+          echo "$(<test-file.json)"
 
-  #     - name: Test output
-  #       run: node ./test-output.js
-  #       env:
-  #         FILES: 'test-file.json'
-  #         EXPECTED_VERSION: '1.5.0'
+      - name: Test output
+        run: node ./test-output.js
+        env:
+          FILES: 'test-file.json'
+          EXPECTED_VERSION: '1.5.0'

--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,6 @@
 
 # Logs
 logs
-*.log
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ This action will bump version, tag commit and generate a changelog with conventi
 - **Optional** `config-file-path`: Path to the conventional changelog config file. If set, the preset setting will be ignored
 - **Optional** `pre-changelog-generation`: Path to the pre-changelog-generation script file. No hook by default.
 - **Optional** `commit-path`: Generate a changelog scoped to a specific directory.
+- **Optional** `skip-tag`: Skip creating a tag for this changelog. Default `false`.
 
 ### Pre-Commit hook
 

--- a/action.yml
+++ b/action.yml
@@ -111,6 +111,11 @@ inputs:
     description: 'Generate a changelog scoped to a specific directory'
     required: false
 
+  skip-tag:
+    description: 'Skip creating the git tag'
+    default: 'false'
+    required: false
+
 outputs:
   changelog:
     description: 'The generated changelog for the new version'

--- a/src/helpers/git.js
+++ b/src/helpers/git.js
@@ -161,7 +161,7 @@ module.exports = new (class Git {
    */
   testHistory = () => {
     if (ENV === 'dont-use-git') {
-      const { EXPECTED_TAG, SKIPPED_COMMIT, EXPECTED_NO_PUSH, SKIPPED_PULL } = process.env
+      const { EXPECTED_TAG, SKIPPED_COMMIT, EXPECTED_NO_PUSH, SKIPPED_PULL, SKIPPED_TAG } = process.env
 
       const expectedCommands = [
         'git config user.name "Conventional Changelog Action"',
@@ -177,7 +177,9 @@ module.exports = new (class Git {
         expectedCommands.push(`git commit -m "chore(release): ${EXPECTED_TAG}"`)
       }
 
-      expectedCommands.push(`git tag -a ${EXPECTED_TAG} -m "${EXPECTED_TAG}"`)
+      if (!SKIPPED_TAG) {
+        expectedCommands.push(`git tag -a ${EXPECTED_TAG} -m "${EXPECTED_TAG}"`)
+      }
 
       if (!EXPECTED_NO_PUSH) {
         expectedCommands.push(`git push origin ${branch} --follow-tags`)

--- a/src/index.js
+++ b/src/index.js
@@ -43,6 +43,7 @@ async function run() {
     const conventionalConfigFile = core.getInput('config-file-path')
     const preChangelogGenerationFile = core.getInput('pre-changelog-generation')
     const path = core.getInput('commit-path')
+    const skipTag = core.getInput('skip-tag').toLowerCase() === 'true'
 
     core.info(`Using "${preset}" preset`)
     core.info(`Using "${gitCommitMessage}" as commit message`)
@@ -89,10 +90,8 @@ async function run() {
 
       let newVersion
 
-      // If skipVersionFile or skipCommit is true we use GIT to determine the new version because
-      // skipVersionFile can mean there is no version file and skipCommit can mean that the user
-      // is only interested in tags
-      if (skipVersionFile || skipCommit) {
+      // If skipVersionFile is true we use GIT to determine the new version
+      if (skipVersionFile) {
         core.info('Using GIT to determine the new version')
         const versioning = await handleVersioningByExtension(
           'git',
@@ -176,7 +175,9 @@ async function run() {
       }
 
       // Create the new tag
-      await git.createTag(gitTag)
+      if(!skipTag) {
+        await git.createTag(gitTag)
+      }
 
       if (gitPush) {
         try {


### PR DESCRIPTION
Add `skip-tag` option to avoid creating a git tag. Useful for directory scoped changelogs.