### PR TITLE
feat: add version-from-git, refactor skip-version-file

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -138,7 +138,8 @@ jobs:
           github-token: ${{ secrets.github_token }}
           skip-commit: 'true'
           skip-version-file: 'true'
-          
+          version-from-git: 'true'
+
   test-git-no-pull:
     runs-on: ubuntu-latest
     steps:
@@ -171,6 +172,7 @@ jobs:
           skip-commit: 'true'
           skip-git-pull: 'true'
           skip-version-file: 'true'
+          version-from-git: 'true'
 
   test-git-fallback:
     runs-on: ubuntu-latest
@@ -201,6 +203,7 @@ jobs:
           github-token: ${{ secrets.github_token }}
           skip-commit: 'true'
           skip-version-file: 'true'
+          version-from-git: 'true'
 
   test-git-no-push:
     runs-on: ubuntu-latest
@@ -234,6 +237,7 @@ jobs:
           skip-commit: 'true'
           git-push: 'false'
           skip-version-file: 'true'
+          version-from-git: 'true'
 
   test-yaml:
     runs-on: ubuntu-latest
@@ -630,6 +634,7 @@ jobs:
         with:
           github-token: ${{ secrets.github_token }}
           skip-version-file: 'true'
+          version-from-git: 'true'
           config-file-path: './test-changelog.config.js'
 
       - name: Test output

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ This action will bump version, tag commit and generate a changelog with conventi
 - **Optional** `pre-changelog-generation`: Path to the pre-changelog-generation script file. No hook by default.
 - **Optional** `commit-path`: Generate a changelog scoped to a specific directory.
 - **Optional** `skip-tag`: Skip creating a tag for this changelog. Default `false`.
+- **Optional** `version-from-git`: Try getting the version from `git` tags instead of using the version file. Default `false`.
 
 ### Pre-Commit hook
 

--- a/action.yml
+++ b/action.yml
@@ -116,6 +116,11 @@ inputs:
     default: 'false'
     required: false
 
+  version-from-git:
+    description: 'Try getting the version from `git` tags instead of using the version file'
+    default: 'false'
+    required: false
+
 outputs:
   changelog:
     description: 'The generated changelog for the new version'

--- a/src/version/base.js
+++ b/src/version/base.js
@@ -7,6 +7,8 @@ module.exports = class BaseVersioning {
 
   versionPath = null
 
+  skipVersionFile = null
+
   newVersion = null
 
   /**
@@ -15,9 +17,10 @@ module.exports = class BaseVersioning {
    * @param {!string} fileLocation - Full location of the file
    * @param {!string} versionPath - Path inside the file where the version is located
    */
-  init = (fileLocation, versionPath) => {
+  init = (fileLocation, versionPath, skipVersionFile) => {
     this.fileLocation = fileLocation
     this.versionPath = versionPath
+    this.skipVersionFile = skipVersionFile
   }
 
   /**

--- a/src/version/json.js
+++ b/src/version/json.js
@@ -38,6 +38,10 @@ module.exports = class Json extends BaseVersioning {
       oldVersion,
     )
 
+    if(this.skipVersionFile) {
+      return
+    }
+
     core.info(`Bumped file "${this.fileLocation}" from "${oldVersion}" to "${this.newVersion}"`)
 
     // Update the content with the new version

--- a/src/version/toml.js
+++ b/src/version/toml.js
@@ -25,6 +25,10 @@ module.exports = class Toml extends BaseVersioning {
       oldVersion,
     )
 
+    if(this.skipVersionFile) {
+      return
+    }
+
     // Update the file
     if (oldVersion) {
       // Get the name of where the version is in

--- a/src/version/xml.js
+++ b/src/version/xml.js
@@ -42,6 +42,10 @@ module.exports = class Xml extends BaseVersioning {
       oldVersion,
     )
 
+    if(this.skipVersionFile) {
+      return
+    }
+
     core.info(`Bumped file "${this.fileLocation}" from "${oldVersion}" to "${this.newVersion}"`)
 
     // Update the content with the new version

--- a/src/version/yaml.js
+++ b/src/version/yaml.js
@@ -25,6 +25,10 @@ module.exports = class Yaml extends BaseVersioning {
       oldVersion,
     )
 
+    if(this.skipVersionFile) {
+      return
+    }
+
     // Update the file
     if (oldVersion) {
       // Get the name of where the version is in


### PR DESCRIPTION
`skip-version-file` now does exactly what the documentation states: update the version file with the new version or not.
Added `version-from-git` to control whether the action should look into `git` tags for the version or not.