### PR TITLE
feat: add support for version in json property names containing dot

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -722,7 +722,7 @@ jobs:
           EXPECTED_VERSION: '1.1.0'
           EXPECTED_VERSION_PATH: 'project.properties.revision'
 
-  test-xml2:
+  test-dot-path:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -735,14 +735,14 @@ jobs:
       - run: touch ./fake-file.log
       - run: "git config --global user.email 'changelog@github.com'"
       - run: "git config --global user.name 'Awesome Github action'"
-      - run: "git add . && git commit -m 'feat: Added fake file so version will be bumped'"
+      - run: "git add . && git commit -m 'fix: Added fake file so version will be bumped'"
 
       - name: Generate changelog
         id: changelog
         uses: ./
         env:
           ENV: 'dont-use-git'
-          EXPECTED_TAG: 'v1.1.0'
+          EXPECTED_TAG: 'v1.0.4'
         with:
           github-token: ${{ secrets.github_token }}
           version-file: 'test-file.xml'
@@ -756,7 +756,7 @@ jobs:
         run: node ./test-output.js
         env:
           FILES: 'test-file.xml'
-          EXPECTED_VERSION: '1.1.0'
+          EXPECTED_VERSION: '1.0.4'
           EXPECTED_VERSION_PATH: 'project.properties."another.thing"'
 
   test-skip-tag:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -722,6 +722,43 @@ jobs:
           EXPECTED_VERSION: '1.1.0'
           EXPECTED_VERSION_PATH: 'project.properties.revision'
 
+  test-xml2:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          path: "./"
+
+      - run: npm ci --prod
+
+      - run: touch ./fake-file.log
+      - run: "git config --global user.email 'changelog@github.com'"
+      - run: "git config --global user.name 'Awesome Github action'"
+      - run: "git add . && git commit -m 'feat: Added fake file so version will be bumped'"
+
+      - name: Generate changelog
+        id: changelog
+        uses: ./
+        env:
+          ENV: 'dont-use-git'
+          EXPECTED_TAG: 'v1.1.0'
+        with:
+          github-token: ${{ secrets.github_token }}
+          version-file: 'test-file.xml'
+          version-path: 'project.properties."another.thing"'
+
+      - name: Show file
+        run: |
+          echo "$(<test-file.xml)"
+
+      - name: Test output
+        run: node ./test-output.js
+        env:
+          FILES: 'test-file.xml'
+          EXPECTED_VERSION: '1.1.0'
+          EXPECTED_VERSION_PATH: 'project.properties."another.thing"'
+
   test-skip-tag:
     runs-on: ubuntu-latest
     steps:

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ This action will bump version, tag commit and generate a changelog with conventi
 - **Optional** `output-file`: File to output the changelog to. Default `CHANGELOG.md`, when providing `'false'` no file will be generated / updated.
 - **Optional** `release-count`: Number of releases to preserve in changelog. Default `5`, use `0` to regenerate all.
 - **Optional** `version-file`: The path to the file that contains the version to bump. Default `./package.json`.
-- **Optional** `version-path`: The place inside the version file to bump. Default `version`.
+- **Optional** `version-path`: The place inside the version file to bump. Use quotes(e.g. `project.version."dot.prop"`) for properties that have dots in their names. Default `version`.
 - **Optional** `skip-git-pull`: Do not pull the repo before tagging. Ensure you full cloned the repo in the first place to get tags. Default `'false'`.
 - **Optional** `skip-on-empty`: Boolean to specify if you want to skip empty release (no-changelog generated). This case occured when you push `chore` commit with `angular` for example. Default `'true'`.
 - **Optional** `skip-version-file`: Do not update the version file. Default `'false'`.

--- a/src/version/base.js
+++ b/src/version/base.js
@@ -21,6 +21,11 @@ module.exports = class BaseVersioning {
     this.fileLocation = fileLocation
     this.versionPath = versionPath
     this.skipVersionFile = skipVersionFile
+
+    if (versionPath.includes('"')) { // if version path has dot separated properties, split path to array
+      let arr = versionPath.match(/(".*?"|[^"\.\s]+)(?=\s*\.|\s*$)/g);
+      this.versionPath = arr.map(e => e.replace(/^"|"$/g, ''))
+    }
   }
 
   /**

--- a/src/version/xml.js
+++ b/src/version/xml.js
@@ -34,10 +34,9 @@ module.exports = class Xml extends BaseVersioning {
     });
 
     core.info(`json-Content: ${JSON.stringify(jsonContent)}`)
-    core.info(`path: ${this.versionPath}`)
+
     // Get the old version
-    // const oldVersion = objectPath.get(jsonContent, this.versionPath, null)
-    const oldVersion = objectPath.get(jsonContent, ["project", "properties", "\"another.thing\""], null)
+    const oldVersion = objectPath.get(jsonContent, this.versionPath, null)
 
     // Get the new version
     this.newVersion = await bumpVersion(

--- a/src/version/xml.js
+++ b/src/version/xml.js
@@ -33,6 +33,7 @@ module.exports = class Xml extends BaseVersioning {
       jsonContent = {}
     });
 
+    core.info(`json-Content: ${jsonContent}`)
     // Get the old version
     const oldVersion = objectPath.get(jsonContent, this.versionPath, null)
 

--- a/src/version/xml.js
+++ b/src/version/xml.js
@@ -33,9 +33,11 @@ module.exports = class Xml extends BaseVersioning {
       jsonContent = {}
     });
 
-    core.info(`json-Content: ${jsonContent}`)
+    core.info(`json-Content: ${JSON.stringify(jsonContent)}`)
+    core.info(`path: ${this.versionPath}`)
     // Get the old version
-    const oldVersion = objectPath.get(jsonContent, this.versionPath, null)
+    // const oldVersion = objectPath.get(jsonContent, this.versionPath, null)
+    const oldVersion = objectPath.get(jsonContent, ["project", "properties", "\"another.thing\""], null)
 
     // Get the new version
     this.newVersion = await bumpVersion(

--- a/test-file.xml
+++ b/test-file.xml
@@ -4,7 +4,7 @@
 
   <properties>
     <revision>1.0.6</revision>
-    <another.thing>1.0.6</another.thing>
+    <another.thing>1.0.3</another.thing>
   </properties>
 
   <modules>

--- a/test-file.xml
+++ b/test-file.xml
@@ -4,7 +4,7 @@
 
   <properties>
     <revision>1.0.6</revision>
-    <another.thing>prop</another.thing>
+    <another.thing>1.0.6</another.thing>
   </properties>
 
   <modules>

--- a/test-file.xml
+++ b/test-file.xml
@@ -4,7 +4,7 @@
 
   <properties>
     <revision>1.0.6</revision>
-    <another>prop</another>
+    <another.thing>prop</another.thing>
   </properties>
 
   <modules>

--- a/test-output.js
+++ b/test-output.js
@@ -7,13 +7,18 @@ const parseString = require('xml2js').parseString
 
 const actionConfig = yaml.parse(fs.readFileSync('./action.yml', 'utf8'))
 
-const {
+let {
   FILES = actionConfig.inputs['version-file'].default,
   EXPECTED_VERSION_PATH = actionConfig.inputs['version-path'].default,
   EXPECTED_VERSION = actionConfig.inputs['fallback-version'].default,
 } = process.env
 
 assert.ok(FILES, 'Files not defined!')
+
+if (EXPECTED_VERSION_PATH.includes('"')) { // if version path has dot separated properties, split path to array
+  let arr = EXPECTED_VERSION_PATH.match(/(".*?"|[^"\.\s]+)(?=\s*\.|\s*$)/g);
+  EXPECTED_VERSION_PATH = arr.map(e => e.replace(/^"|"$/g, ''))
+}
 
 /**
  * Test if all the files are updated


### PR DESCRIPTION
Add support for reading the version from json property names containing dot, like `dot.property`.
`version-path` should contain `"` around properties that have `.` in the name, e.g: `project.version."dot.property"`.